### PR TITLE
Added workaround to fix Remote link for Opera

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -606,7 +606,10 @@ function OpenViaRemote() {
         var bounds = selectedFeature.geometry.getBounds().toArray()
         var p1 = (new OpenLayers.LonLat(bounds[0], bounds[1])).transform(from, to);
         var p2 = (new OpenLayers.LonLat(bounds[2], bounds[3])).transform(from, to);
-        $.get("http://127.0.0.1:8111/load_and_zoom", {left: p1.lon, right: p2.lon, top: p2.lat, bottom: p1.lat});
+        if ( !$('#hiddenIframe').length ){
+            $('body').append('<iframe id="hiddenIframe" style="display:hidden" />');
+        }
+        $('#hiddenIframe').attr("src", "http://127.0.0.1:8111/load_and_zoom?left=" + p1.lon + "&right=" + p2.lon + "&top=" + p2.lat + "&bottom=" + p1.lat);
     }
 }
 


### PR DESCRIPTION
Hey, Foxhind. I'd like to suggest workaround for Remote button to work in Opera browser. See #22 [bug] WMS Remote control link on /list does not work in opera
