### PR TITLE
Allow logged in users to update a slice *so long as there is no owner*

### DIFF
--- a/logic/pieces.php
+++ b/logic/pieces.php
@@ -132,7 +132,8 @@ function handle_piece_state($type, $from, $data, $res)
         throw new Exception("This slice doesn't exist.");
 
     $owner = pg_fetch_result($result, 0 ,0);
-    if ($owner !== $from->user_id() && !$admin_mode)
+
+    if (!empty($owner) && $owner !== $from->user_id() && !$admin_mode)
         throw new Exception("This is not your slice");
 
     $result = pg_query($connection, 'UPDATE pieces SET state = '.$state.' WHERE id = '.$piece_id);


### PR DESCRIPTION
As a logged in user, often I'm working alone on my own cakes. Sometimes I'll forget to claim a slice, and try to update it, which fails - asking me to take ownership.

Instead of failing and hassling me, I'd suggest allowing the edit - so long as no one else owns the slice.
